### PR TITLE
chore: fix "models" keyword in compose files

### DIFF
--- a/go-genai/docker-compose.yml
+++ b/go-genai/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
-    x-genai-models:
+    models:
       - llama
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]

--- a/node-genai/docker-compose.yml
+++ b/node-genai/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "8082:8080"
     environment:
       - PORT=8080
-    x-genai-models:
+    models:
       - llama
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]

--- a/py-genai/docker-compose.yml
+++ b/py-genai/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - PORT=8080
       - LOG_LEVEL=INFO
-    x-genai-models:
+    models:
       - llama
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]

--- a/rust-genai/docker-compose.yaml
+++ b/rust-genai/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - "8083:8080"
     environment:
       - PORT=8080
-    x-genai-models:
+    models:
       - llama
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]


### PR DESCRIPTION
- replacing outdated "x-genai-models" keyword with new `models` syntax
- making docker compose recognizing back the model when running with [convention over configuration](https://docs.docker.com/ai/compose/models-and-compose/#short-syntax) env variables

```bash
$ docker compose up
Attaching to go-genai-1
go-genai-1  | [hello-genai] 2025/10/29 17:33:28 WARNING: No LLM endpoint configured. Set LLAMA_URL.
go-genai-1  | [hello-genai] 2025/10/29 17:33:28 WARNING: No LLM model configured. Set LLAMA_MODEL.

$ docker compose up
[+] Running 1/2
 ⠋ llama Configuring                                                       0.1s
 ✔ Container go-genai-go-genai-1  Recre...                                 0.0s
Attaching to go-genai-1
go-genai-1  | [hello-genai] 2025/10/29 17:42:02 Configuration loaded: Port=8080, LLM Base URL=http://model-runner.docker.internal/engines/v1/, Model=ai/llama3.2:1B-Q8_0
go-genai-1  | [hello-genai] 2025/10/29 17:42:02 Current working directory: /app
go-genai-1  | [hello-genai] 2025/10/29 17:42:02 Static directory exists
go-genai-1  | [hello-genai] 2025/10/29 17:42:02 swagger.json exists
go-genai-1  | [hello-genai] 2025/10/29 17:42:02 Server starting on http://localhost:8080
go-genai-1  | [hello-genai] 2025/10/29 17:42:02 Using LLM endpoint: http://model-runner.docker.internal/engines/v1//chat/completions
go-genai-1  | [hello-genai] 2025/10/29 17:42:02 Using model: ai/llama3.2:1B-Q8_0
```