### PR TITLE
feat: add PR review workflows for issue comments and pull requests

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,0 +1,33 @@
+name: PR Review - Trigger
+on:
+  pull_request:
+    types: [ready_for_review, opened]
+  pull_request_review_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  save-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save event context
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_JSON: ${{ toJSON(github.event.comment) }}
+        run: |
+          mkdir -p context
+          printf '%s' "${{ github.event_name }}" > context/event_name.txt
+          printf '%s' "$PR_NUMBER" > context/pr_number.txt
+          printf '%s' "$PR_HEAD_SHA" > context/pr_head_sha.txt
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            printf '%s' "$COMMENT_JSON" > context/comment.json
+          fi
+
+      - name: Upload context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-review-context
+          path: context/
+          retention-days: 1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,26 @@
+name: PR Review
+on:
+  issue_comment:
+    types: [created]
+  workflow_run:
+    workflows: ["PR Review - Trigger"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    if: |
+      github.event_name == 'issue_comment' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@d98096f432f2aea5091c811852c4da804e60623a # v1.4.1
+    permissions:
+      contents: read # Read repository files and PR diffs
+      pull-requests: write # Post review comments
+      issues: write # Create security incident issues if secrets detected
+      checks: write # (Optional) Show review progress as a check run
+      id-token: write # Required for OIDC authentication to AWS Secrets Manager
+      actions: read # Download artifacts from trigger workflow
+    with:
+      trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}', github.event.workflow_run.id) || '' }}


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate and streamline the pull request review process. The first workflow, `PR Review - Trigger`, captures and uploads relevant context when a pull request is opened, marked ready for review, or receives a review comment. The second workflow, `PR Review`, listens for specific events and delegates the review process to a reusable workflow, handling permissions and artifact retrieval.

**New Pull Request Review Automation Workflows:**

* **Trigger workflow for PR events:**  
  - Added `.github/workflows/pr-review-trigger.yml` to capture context (PR number, head SHA, and review comment data) when a pull request is opened, marked ready for review, or receives a new review comment, and uploads this context as an artifact.

* **Main review workflow orchestration:**  
  - Added `.github/workflows/pr-review.yml` to listen for new issue comments and completion of the trigger workflow, and then runs the main review job using a reusable workflow, with appropriate permissions for reading repository contents, posting comments, and handling artifacts.