### PR TITLE
refactor: extract shared models.yml to eliminate model config duplication

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1.2.0
+        uses: docker/setup-compose-action@364cc21a5de5b1ee4a7f5f9d3fa374ce0ccde746 # v1.2.0
         with:
           version: v2.40.3
 

--- a/go-genai/docker-compose.yml
+++ b/go-genai/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - path: ../models.yml
+
 services:
   go-genai:
     build:
@@ -15,8 +18,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-
-models:
-  llama:
-    model: ai/llama3.2:1B-Q8_0
-    context_size: 2048

--- a/models.yml
+++ b/models.yml
@@ -1,0 +1,4 @@
+models:
+  llama:
+    model: ai/llama3.2:1B-Q8_0
+    context_size: 2048

--- a/node-genai/docker-compose.yml
+++ b/node-genai/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - path: ../models.yml
+
 services:
   node-genai:
     build:
@@ -15,8 +18,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-
-models:
-  llama:
-    model: ai/llama3.2:1B-Q8_0
-    context_size: 2048

--- a/py-genai/docker-compose.yml
+++ b/py-genai/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - path: ../models.yml
+
 services:
   python-genai:
     build:
@@ -16,8 +19,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-
-models:
-  llama:
-    model: ai/llama3.2:1B-Q8_0
-    context_size: 2048

--- a/rust-genai/docker-compose.yaml
+++ b/rust-genai/docker-compose.yaml
@@ -1,3 +1,6 @@
+include:
+  - path: ../models.yml
+
 services:
   rust-genai:
     build:
@@ -15,8 +18,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-
-models:
-  llama:
-    model: ai/llama3.2:1B-Q8_0
-    context_size: 2048


### PR DESCRIPTION
## Summary
- Move the duplicated `models:` block out of all four service compose files
  (`go-genai`, `node-genai`, `py-genai`, `rust-genai`) into a single shared
  `models.yml` at the project root.
- Each service now pulls it in via Compose's `include:` directive
  (`include: [{ path: ../models.yml }]`), so the `llama` model config lives in
  one place instead of being repeated 4×.

## Why
Removes config duplication — updating the model (name, context size, etc.) is
now a one-line change in `models.yml` rather than four separate edits.

## Test plan
- [x] CI `smoke-tests.yml` passes for all four services (Compose v2.40.3 +
      Docker Model Runner) — exercises `docker compose up` per service, which
      resolves the new `../models.yml` include.
- [x] `/health`, `/`, and `/api/chat` respond for go/py/node/rust services.

Note: requires Docker Compose ≥ v2.40 (the `models:` element); older versions
don't recognize it.