### PR TITLE
fix: install curl in node-genai image for healthcheck

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1.2.0
+        uses: docker/setup-compose-action@364cc21a5de5b1ee4a7f5f9d3fa374ce0ccde746 # v1.2.0
         with:
           version: v2.40.3
 

--- a/node-genai/Dockerfile
+++ b/node-genai/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:20-alpine
 
+# curl is required by the docker-compose healthcheck (not present in node:alpine)
+RUN apk add --no-cache curl
+
 WORKDIR /app
 
 # Copy package files


### PR DESCRIPTION
## Summary
- `node-genai`'s compose healthcheck runs `curl -f http://localhost:8080/health`,
  but the `node:20-alpine` base image doesn't ship `curl`. Every probe failed
  with `curl: executable file not found`, so the container was permanently
  marked **unhealthy** even though `/health` responds correctly.
- Add `RUN apk add --no-cache curl` to `node-genai/Dockerfile` so the
  healthcheck works, matching the other three services.

## Why it went unnoticed
The smoke-test workflow polls `/health` from the runner host (not via the
container's HEALTHCHECK), so CI passed while the container's own health status
stayed `unhealthy`.

## Test plan
- [x] Rebuilt the image locally; `curl` now present at `/usr/bin/curl`.
- [x] Ran the exact healthcheck command in the container — returns
      `{"status":"healthy",...}` with exit 0.
- [x] CI smoke tests pass for all four services.