### PR TITLE
chore: migrate cagent-action to docker-agent-action (v2.0.0)

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,7 +1,7 @@
 name: PR Review - Trigger
 on:
   pull_request:
-    types: [ready_for_review, opened]
+    types: [ready_for_review, opened, review_requested]
   pull_request_review_comment:
     types: [created]
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,10 +11,7 @@ permissions:
 
 jobs:
   review:
-    if: |
-      github.event_name == 'issue_comment' ||
-      github.event.workflow_run.conclusion == 'success'
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@d98096f432f2aea5091c811852c4da804e60623a # v1.4.1
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
     permissions:
       contents: read # Read repository files and PR diffs
       pull-requests: write # Post review comments


### PR DESCRIPTION
## Summary

`docker/cagent-action` has moved to a new repository: `docker/docker-agent-action`.
GitHub Actions `uses:` references must be updated explicitly, so this PR migrates all references and pins them to [v2.0.0](https://github.com/docker/docker-agent-action/releases/tag/v2.0.0).

- **New repository**: `docker/docker-agent-action`
- **Pinned commit**: `3c0fa9d282c3f84d08dfd70ab0a28b151d11db70`
- **Version**: `v2.0.0`

ℹ️ The old `docker/cagent-action` repo remains functional, so there is no deadline — merge whenever convenient. New features and fixes land in the new repo, which is where you'll want to be going forward.

> Auto-generated by the [migrate-consumers](https://github.com/docker/docker-agent-action/actions/runs/28023540082) workflow.